### PR TITLE
Only set session store if session driver is set

### DIFF
--- a/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
+++ b/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Understand\UnderstandLaravel5;
 
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\AliasLoader;
 
@@ -72,7 +73,9 @@ class UnderstandLaravel5ServiceProvider extends ServiceProvider
         {
             $fieldProvider = new FieldProvider();
 
-            $fieldProvider->setSessionStore($app['session.store']);
+	    if (Session::getDefaultDriver()) {
+                $fieldProvider->setSessionStore($app['session.store']);
+            }
             $fieldProvider->setRouter($app['router']);
             $fieldProvider->setRequest($app['request']);
             $fieldProvider->setEnvironment($app->environment());

--- a/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
+++ b/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
@@ -1,6 +1,5 @@
 <?php namespace Understand\UnderstandLaravel5;
 
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\AliasLoader;
 
@@ -73,7 +72,8 @@ class UnderstandLaravel5ServiceProvider extends ServiceProvider
         {
             $fieldProvider = new FieldProvider();
 
-	    if (Session::getDefaultDriver()) {
+	    if ($app['config']['session.driver']) 
+	    {
                 $fieldProvider->setSessionStore($app['session.store']);
             }
             $fieldProvider->setRouter($app['router']);


### PR DESCRIPTION
Without this, you cannot use the logger unless you're using a session driver and get the following error:

Error:
```bash
ErrorException: Missing argument 1 for Illuminate\Support\Manager::createDriver()
```