### PR TITLE
Catch `\Throwable` before `\Exception`

### DIFF
--- a/src/Understand/UnderstandLaravel5/ExceptionEncoder.php
+++ b/src/Understand/UnderstandLaravel5/ExceptionEncoder.php
@@ -216,6 +216,8 @@ class ExceptionEncoder
 
             return $codeLines;
         }
+        catch (\Throwable $e)
+        {}
         catch (\Exception $e)
         {}
     }

--- a/src/Understand/UnderstandLaravel5/FieldProvider.php
+++ b/src/Understand/UnderstandLaravel5/FieldProvider.php
@@ -431,6 +431,8 @@ class FieldProvider
                 return $userId;
             }
         }
+        catch (\Throwable $e)
+        {}
         catch (\Exception $e)
         {}
 
@@ -441,6 +443,8 @@ class FieldProvider
                 return $user->id;
             }
         }
+        catch (\Throwable $e)
+        {}
         catch (\Exception $e)
         {}
 
@@ -451,6 +455,8 @@ class FieldProvider
                 return $user->id;
             }
         }
+        catch (\Throwable $e)
+        {}
         catch (\Exception $e)
         {}
     }

--- a/src/Understand/UnderstandLaravel5/Logger.php
+++ b/src/Understand/UnderstandLaravel5/Logger.php
@@ -153,6 +153,10 @@ class Logger
         {
             return $this->handler->handle($event);
         }
+        catch (\Throwable $e)
+        {
+            return false;
+        }
         catch (\Exception $ex)
         {
             return false;

--- a/tests/FieldProviderTest.php
+++ b/tests/FieldProviderTest.php
@@ -29,7 +29,7 @@ class FieldProviderTest extends Orchestra\Testbench\TestCase
 
         $this->assertSame($value, $fieldProvider->{$method}());
     }
-    
+
     public function testLaravelAuth()
     {
         $userId = 23452345;
@@ -69,6 +69,18 @@ class FieldProviderTest extends Orchestra\Testbench\TestCase
         $currentUserId = $this->app['understand.fieldProvider']->getUserId();
 
         $this->assertSame($user->id, $currentUserId);
+    }
+
+    public function testFieldProviderThrowsAnException()
+    {
+        $loader = AliasLoader::getInstance();
+        $loader->alias('Sentry', '\Illuminate\Support\Facades\Auth');
+
+        \Illuminate\Support\Facades\Auth::shouldReceive('getUser')->andThrow('Exception');
+
+        $currentUserId = $this->app['understand.fieldProvider']->getUserId();
+
+        $this->assertNull($currentUserId);
     }
 
     public function testQueryCount()


### PR DESCRIPTION
Related to #26 

Some exceptions from PHP 7 are implementing \Throwable interface (see http://php.net/manual/en/language.errors.php7.php), so type/parse errors might not be caught with the current implementation.

Since this library supports PHP 5, we can implement multiple `catch()` blocks without breaking changes.

This PR makes sure that all kinds of errors & exceptions are caught, especially when getting authenticated user context from `FieldProvider` class.