### PR TITLE
[FEATURE] Log filter

### DIFF
--- a/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
+++ b/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
@@ -434,22 +434,27 @@ class UnderstandLaravel5ServiceProvider extends ServiceProvider
         }
     }
 
-    /**
-     * @param $level
-     * @param $message
-     * @param $context
-     * @return bool
-     */
     protected function shouldIgnoreEvent($level, $message, $context)
     {
         $ignoredEventTypes = (array)$this->app['config']->get('understand-laravel.ignored_logs');
+        $logFilter = $this->app['config']->get('understand-laravel.log_filter');
 
-        if ( ! $ignoredEventTypes)
+        // check if the log should be ignored by its level (info, warning, etc.)
+        if ($ignoredEventTypes)
         {
-            return false;
+            return in_array($level, $ignoredEventTypes, true);
         }
 
-        return in_array($level, $ignoredEventTypes, true);
+        // check if a custom filter is set and whether the log should be ignored
+        // true - the log should be ignored
+        // false - the log should be delivered to Understand
+        if (is_callable($logFilter))
+        {
+            return (bool)$logFilter($level, $message, $context);
+        }
+
+        // by default logs are not ignored
+        return false;
     }
 
     /**

--- a/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
+++ b/src/Understand/UnderstandLaravel5/UnderstandLaravel5ServiceProvider.php
@@ -448,9 +448,11 @@ class UnderstandLaravel5ServiceProvider extends ServiceProvider
         // check if a custom filter is set and whether the log should be ignored
         // true - the log should be ignored
         // false - the log should be delivered to Understand
-        if (is_callable($logFilter))
+        if ($logFilter)
         {
-            return (bool)$logFilter($level, $message, $context);
+            $factory = is_callable($logFilter) ? $logFilter : $this->app->make($logFilter);
+
+            return (bool)$factory($level, $message, $context);
         }
 
         // by default logs are not ignored

--- a/src/config/understand-laravel.php
+++ b/src/config/understand-laravel.php
@@ -67,6 +67,25 @@ return [
     ],
 
     /**
+     * Log filter.
+     *
+     * The configuration value (filter) must be a callable type:
+     * - https://www.php.net/manual/en/function.is-callable.php
+     *
+     * The suggested way would be to create an invokable class since it's hard to serialise anonymous functions (Laravel config cache):
+     * - https://www.php.net/manual/en/language.oop5.magic.php#object.invoke
+     *
+     * The log (callable) filter interface is as follows: `$callable($level, $message, $context)`.
+     *
+     * The result of the filter must be a boolean value:
+     * - TRUE, the log should be ignored and NOT delivered to Understand.io
+     * - FALSE, the log should be delivered to Understand.io
+     *
+     * The `ignored_logs` config value has higher precedence than `log_filter`.
+     */
+    'log_filter' => null,
+
+    /**
      * Field names which values should not be sent to Understand.io
      * It applies to POST and GET request parameters
      */

--- a/src/config/understand-laravel.php
+++ b/src/config/understand-laravel.php
@@ -71,6 +71,8 @@ return [
      *
      * The configuration value (filter) must be a callable type:
      * - https://www.php.net/manual/en/function.is-callable.php
+     * or a callable dependency from the service container:
+     * - https://laravel.com/docs/9.x/container#the-make-method
      *
      * The suggested way would be to create an invokable class since it's hard to serialise anonymous functions (Laravel config cache):
      * - https://www.php.net/manual/en/language.oop5.magic.php#object.invoke

--- a/tests/LogFilterTest.php
+++ b/tests/LogFilterTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Understand\UnderstandLaravel5\Logger;
+use Understand\UnderstandLaravel5\Handlers\CallbackHandler;
+use Understand\UnderstandLaravel5\UnderstandLaravel5ServiceProvider;
+
+class LogFilterTest extends Orchestra\Testbench\TestCase
+{
+
+    /**
+     * Setup service provider
+     *
+     * @param object $app
+     * @return void
+     */
+    protected function getPackageProviders($app)
+    {
+        return [UnderstandLaravel5ServiceProvider::class];
+    }
+
+    /**
+     * @return void
+     */
+    public function testLogFilterAllowsDelivery()
+    {
+        $logsSent = 0;
+
+        $callback = function() use(&$logsSent)
+        {
+            $logsSent++;
+        };
+
+        $this->app['config']->set('understand-laravel.log_filter', function() {
+            // FALSE, logs should not be filtered
+            return false;
+        });
+
+        $handler = new CallbackHandler($callback);
+        $this->app['understand.logger'] = new Logger($this->app['understand.fieldProvider'], $handler);
+
+        // trigger error
+        $this->app['Psr\Log\LoggerInterface']->error('test');
+        $this->app['Psr\Log\LoggerInterface']->warning('test2');
+
+        $this->assertEquals(2, $logsSent);
+    }
+
+    /**
+     * @return void
+     */
+    public function testLogFilterFiltersOneLog()
+    {
+        $logsSent = 0;
+
+        $callback = function() use(&$logsSent)
+        {
+            $logsSent++;
+        };
+
+        $this->app['config']->set('understand-laravel.log_filter', function($level, $message, $context) {
+            if ($message === 'test2') {
+                // TRUE, log should be filtered
+                return true;
+            }
+
+            // FALSE, logs should not be filtered
+            return false;
+        });
+
+        $handler = new CallbackHandler($callback);
+        $this->app['understand.logger'] = new Logger($this->app['understand.fieldProvider'], $handler);
+
+        // trigger error
+        $this->app['Psr\Log\LoggerInterface']->error('test');
+        $this->app['Psr\Log\LoggerInterface']->warning('test2');
+
+        $this->assertEquals(1, $logsSent);
+    }
+
+    /**
+     * @return void
+     */
+    public function testLogFilterReceivesAllData()
+    {
+        $logsSent = 0;
+
+        $callback = function() use(&$logsSent)
+        {
+            $logsSent++;
+        };
+
+        $this->app['config']->set('understand-laravel.log_filter', function($level, $message, $context) {
+            $this->assertEquals('error', $level);
+            $this->assertEquals('test', $message);
+            $this->assertEquals(['context' => 'value'], $context);
+
+            // FALSE, logs should not be filtered
+            return false;
+        });
+
+        $handler = new CallbackHandler($callback);
+        $this->app['understand.logger'] = new Logger($this->app['understand.fieldProvider'], $handler);
+
+        // trigger error
+        $this->app['Psr\Log\LoggerInterface']->error('test', ['context' => 'value']);
+
+        $this->assertEquals(1, $logsSent);
+    }
+}


### PR DESCRIPTION
### Log filter

The Understand service provider utilises the event dispatcher (`MessageLogged` event) to capture and deliver logs. This makes it impossible to filter specific log types at the application level even if a custom Laravel log driver is created (the event dispatcher still fires the event).

A good use case example for this is to filter out PHP8 deprecation warnings.

#### Example filter class
```php
<?php
// config (understand-laravel.php)
'log_filter' => \App\Logging\UnderstandLogFilter::class,

// a hypothetical filter class
<?php

declare(strict_types=1);

namespace App\Logging;

use Illuminate\Support\Str;

class UnderstandLogFilter
{
    public function __invoke($level, $message, $context): bool
    {
        if ($level === 'warning' && Str::contains(strtolower($message), 'deprecated')) {
            return true;
        }

        return false;
    }
}
```

#### Configuration details
The configuration value (filter) must be a callable type:
 - https://www.php.net/manual/en/function.is-callable.php
or a callable dependency from the service container:
 - https://laravel.com/docs/9.x/container#the-make-method
     
The suggested way would be to create an invokable class since it's hard to serialise anonymous functions (Laravel config cache):
 - https://www.php.net/manual/en/language.oop5.magic.php#object.invoke
     
The log (callable) filter interface is as follows: `$callable($level, $message, $context)`.
     
The result of the filter must be a boolean value:
 - `TRUE`, the log should be ignored and NOT delivered to Understand.io
 - `FALSE`, the log should be delivered to Understand.io
     
The `ignored_logs` config value has higher precedence than `log_filter`. 

     